### PR TITLE
Type cast port to integer

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -53,7 +53,7 @@ class Bootstrap implements BootstrapInterface
         foreach (range(1, getenv('MEMCACHE_COUNT')) as $num) {
             $servers[] = [
                 'host'          => getenv('MEMCACHE_HOST' . $num),
-                'port'          => getenv('MEMCACHE_PORT' . $num),
+                'port'          => (int) getenv('MEMCACHE_PORT' . $num),
                 'weight'        => 1,
             ];
         }


### PR DESCRIPTION
@ostark I believe this is needed to avoid the following exception.

```
Warning: Memcached::addServer() expects parameter 2 to be int, string given
```