### PR TITLE
Cache mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0] - UNRELEASED
+## [1.3.0] - 2022-01-25
 - depends on Craft 3.7.30
-- uses Cache mutex (memcached) 
+- uses Cache mutex (Memcached driver) 
 
 ## [1.2.0] - 2021-02-08
 - added `fortrabbit\MemcachedEnabler\MemCache` class 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0] - UNRELEASED
+- depends on Craft 3.7.30
+- uses Cache mutex (memcached) 
+
 ## [1.2.0] - 2021-02-08
 - added `fortrabbit\MemcachedEnabler\MemCache` class 
 - wrapped `setValues()` and `setValue()` in a try / catch 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yii2/Craft3 memcached enabler
+# Craft3 memcached enabler
 
 This yii-extension is a memcached drop in replacement for sessions and cache. 
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "fortrabbit/yii-memcached",
   "description": "Memcached Session & Cache for Craft3 / Yii2 on fortrabbit",
   "type": "yii2-extension",
-  "keywords": ["yii2", "craftcms", "caching", "cache", "memcached", "memcache", "session"],
+  "keywords": ["yii2", "craftcms", "caching", "cache", "memcached", "memcache", "session", "mutex"],
   "license": "MIT",
   "authors": [
     {
@@ -17,7 +17,7 @@
     "docs": "https://github.com/fortrabbit/yii-memcached"
   },
   "require": {
-    "craftcms/cms": "^3.0.0"
+    "craftcms/cms": "^3.7.30"
   },
   "autoload": {
     "psr-4": {

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -5,7 +5,6 @@ namespace fortrabbit\MemcachedEnabler;
 use craft\mutex\Mutex;
 use yii\base\BootstrapInterface;
 use yii\base\InvalidConfigException;
-use yii\di\Instance;
 
 /**
  * Class Bootstrap

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -5,6 +5,7 @@ namespace fortrabbit\MemcachedEnabler;
 use craft\mutex\Mutex;
 use yii\base\BootstrapInterface;
 use yii\base\InvalidConfigException;
+use yii\di\Instance;
 
 /**
  * Class Bootstrap
@@ -14,7 +15,6 @@ use yii\base\InvalidConfigException;
  */
 class Bootstrap implements BootstrapInterface
 {
-
     const TIMEOUT_IN_MILLISECONDS = 50;
 
     /**

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -2,6 +2,7 @@
 
 namespace fortrabbit\MemcachedEnabler;
 
+use craft\mutex\Mutex;
 use yii\base\BootstrapInterface;
 use yii\base\InvalidConfigException;
 
@@ -19,7 +20,7 @@ class Bootstrap implements BootstrapInterface
     /**
      * Bootstrapper
      *
-     * @param \yii\base\Application $app
+     * @param \yii\base\Application|\craft\web\Application|\craft\console\Application $app
      */
     public function bootstrap($app)
     {
@@ -29,15 +30,23 @@ class Bootstrap implements BootstrapInterface
             // Set cache component
             try {
                 $app->set('cache', [
-                    'class'        => MemCache::class,
+                    'class' => MemCache::class,
                     'persistentId' => getenv('MEMCACHE_PERSISTENT') ? 'cache' : null,
-                    'servers'      => $this->getMemcachedServers(),
-                    'options'      => $this->getOptions(),
+                    'servers' => $this->getMemcachedServers(),
+                    'options' => $this->getOptions(),
                     'useMemcached' => true
                 ]);
             } catch (InvalidConfigException $e) {
                 error_log('MemcachedEnabler: ' . $e->getMessage());
             }
+
+            // Set mutex component using the CacheMutex that with
+            // the `cache` configured previously
+            $app->set('mutex', [
+                'class' => Mutex::class,
+                'mutex' => new CacheMutex($app->getCache()),
+            ]);
+
         }
     }
 
@@ -51,9 +60,9 @@ class Bootstrap implements BootstrapInterface
 
         foreach (range(1, getenv('MEMCACHE_COUNT')) as $num) {
             $servers[] = [
-                'host'          => getenv('MEMCACHE_HOST' . $num),
-                'port'          => (int) getenv('MEMCACHE_PORT' . $num),
-                'weight'        => 1,
+                'host' => getenv('MEMCACHE_HOST' . $num),
+                'port' => (int)getenv('MEMCACHE_PORT' . $num),
+                'weight' => 1,
             ];
         }
 
@@ -75,24 +84,24 @@ class Bootstrap implements BootstrapInterface
             \Memcached::OPT_REMOVE_FAILED_SERVERS => true,
 
             // ... retried after a short while (here: 2 seconds)
-            \Memcached::OPT_RETRY_TIMEOUT         => 2,
+            \Memcached::OPT_RETRY_TIMEOUT => 2,
 
             // KETAMA must be enabled so that replication can be used
-            \Memcached::OPT_LIBKETAMA_COMPATIBLE  => true,
+            \Memcached::OPT_LIBKETAMA_COMPATIBLE => true,
 
             // Replicate the data, i.e. write it to both memcached servers
-            \Memcached::OPT_NUMBER_OF_REPLICAS    => 1,
+            \Memcached::OPT_NUMBER_OF_REPLICAS => 1,
 
             // Those values assure that a dead (due to increased latency or
             // really unresponsive) memcached server increased dropped fast
             // and the other is used.
-            \Memcached::OPT_POLL_TIMEOUT          => self::TIMEOUT_IN_MILLISECONDS,           // milliseconds
-            \Memcached::OPT_SEND_TIMEOUT          => self::TIMEOUT_IN_MILLISECONDS * 1000,    // microseconds
-            \Memcached::OPT_RECV_TIMEOUT          => self::TIMEOUT_IN_MILLISECONDS * 1000,    // microseconds
-            \Memcached::OPT_CONNECT_TIMEOUT       => self::TIMEOUT_IN_MILLISECONDS,           // milliseconds
+            \Memcached::OPT_POLL_TIMEOUT => self::TIMEOUT_IN_MILLISECONDS,           // milliseconds
+            \Memcached::OPT_SEND_TIMEOUT => self::TIMEOUT_IN_MILLISECONDS * 1000,    // microseconds
+            \Memcached::OPT_RECV_TIMEOUT => self::TIMEOUT_IN_MILLISECONDS * 1000,    // microseconds
+            \Memcached::OPT_CONNECT_TIMEOUT => self::TIMEOUT_IN_MILLISECONDS,           // milliseconds
 
             // Further performance tuning
-            \Memcached::OPT_NO_BLOCK              => true,
+            \Memcached::OPT_NO_BLOCK => true,
         ];
     }
 }

--- a/src/CacheMutex.php
+++ b/src/CacheMutex.php
@@ -25,10 +25,10 @@ class CacheMutex extends \yii\mutex\Mutex
     public $cache;
 
 
-    public function __construct(CacheInterface $cache)
+    public function __construct(CacheInterface $cache, array $config = [])
     {
         $this->cache = $cache;
-        parent::__construct();
+        parent::__construct($config);
     }
 
     /**

--- a/src/CacheMutex.php
+++ b/src/CacheMutex.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace fortrabbit\MemcachedEnabler;
+
+use yii\caching\CacheInterface;
+
+class CacheMutex
+{
+    const CACHE_VALUE = 1;
+
+    /**
+     * @var int Number of milliseconds between each try in [[acquire()]] until specified timeout times out.
+     * By default it is 200 milliseconds - it means that [[acquire()]] may try acquiring up to 5 times per second.
+     */
+    public $retryDelay = 200;
+
+    /**
+     * @var int the number of seconds in which the lock will be auto released.
+     */
+    public $expire = 30;
+
+    /**
+     * @var \yii\caching\CacheInterface
+     */
+    public $cache;
+
+
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param string $name
+     * @param int $timeout in seconds
+     *
+     * @return bool
+     */
+    public function acquire(string $name, int $timeout = 0): bool
+    {
+        $remainingTimeInMilliseconds = $timeout * 1000;
+
+        // Retry until no time left
+        while ($this->isAcquired($name) && $remainingTimeInMilliseconds > 0) {
+            $remainingTimeInMilliseconds = $remainingTimeInMilliseconds - $this->retryDelay;
+        }
+
+        // Still acquired?
+        if ($this->isAcquired($name)) {
+            return false;
+        }
+
+        return $this->cache->set($name, self::CACHE_VALUE, $this->expire);
+    }
+
+
+    public function release(string $name): bool
+    {
+        return $this->cache->delete($name);
+    }
+
+
+    public function isAcquired(string $name): bool
+    {
+        return (bool) $this->cache->get($name);
+    }
+}


### PR DESCRIPTION
Use Memcached as "Mutex storage".

@see https://github.com/craftcms/cms/blob/develop/CHANGELOG.md#3730---2022-01-20
@see https://github.com/fortrabbit/yii-memcached/issues/5

